### PR TITLE
Support repeated flags

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,46 @@
+# Go
+# Build your Go project.
+# Add steps that test, save build artifacts, deploy, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/go
+
+trigger:
+  branches:
+    include:
+      - refs/heads/master
+      - refs/tags/*
+
+pool:
+  vmImage: 'Ubuntu 16.04'
+
+variables:
+  GOBIN:  '$(GOPATH)/bin' # Go binaries path
+  GOROOT: '/usr/local/go1.11' # Go installation path
+  GOPATH: '$(system.defaultWorkingDirectory)/gopath' # Go workspace path
+  modulePath: '$(GOPATH)/src/github.com/$(build.repository.name)' # Path to the module's code
+
+steps:
+- script: |
+    mkdir -p '$(GOBIN)'
+    mkdir -p '$(GOPATH)/pkg'
+    mkdir -p '$(modulePath)'
+    shopt -s extglob
+    mv !(gopath) '$(modulePath)'
+    echo '##vso[task.prependpath]$(GOBIN)'
+    echo '##vso[task.prependpath]$(GOROOT)/bin'
+  displayName: 'Set up the Go workspace'
+
+- script: |
+     make verify build test-unit
+  workingDirectory: '$(modulePath)'
+  displayName: 'Unit Test'
+
+- script: |
+    make xbuild-all
+  workingDirectory: '$(modulePath)'
+  displayName: 'Cross Compile'
+
+- script: |
+    AZURE_STORAGE_CONNECTION_STRING=$(AZURE_STORAGE_CONNECTION_STRING) make publish
+  workingDirectory: '$(modulePath)'
+  displayName: 'Publish'
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -78,9 +79,10 @@ func (m *Mixin) Execute() error {
 	}
 
 	// Append the flags to the argument list
+	sort.Sort(step.Flags)
 	for _, flag := range step.Flags {
 		for _, value := range flag.Values {
-			args = append(args, fmt.Sprintf("--%s", flag))
+			args = append(args, fmt.Sprintf("--%s", flag.Name))
 			args = append(args, value)
 		}
 	}

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -61,7 +61,10 @@ func (m *Mixin) Execute() error {
 	}
 	step := action.Steps[0]
 
-	fmt.Fprintf(m.Out, "Starting installation operations: %s\n", step.Description)
+	// Always output json so that we can query it for outputs afterwards
+	step.Flags = append(step.Flags, NewFlag("output", "json"))
+
+	fmt.Fprintf(m.Out, "Starting operation: %s\n", step.Description)
 
 	args := make([]string, 0, 2+len(step.Arguments)+len(step.Flags)*2)
 
@@ -75,9 +78,11 @@ func (m *Mixin) Execute() error {
 	}
 
 	// Append the flags to the argument list
-	for flag, value := range step.Flags {
-		args = append(args, fmt.Sprintf("--%s", flag))
-		args = append(args, value)
+	for _, flag := range step.Flags {
+		for _, value := range flag.Values {
+			args = append(args, fmt.Sprintf("--%s", flag))
+			args = append(args, value)
+		}
 	}
 
 	cmd := m.NewCommand("aws", args...)
@@ -96,7 +101,7 @@ func (m *Mixin) Execute() error {
 		prettyCmd := fmt.Sprintf("%s %s", cmd.Path, strings.Join(cmd.Args, " "))
 		return errors.Wrap(err, fmt.Sprintf("error running command %s", prettyCmd))
 	}
-	fmt.Fprintf(m.Out, "Finished installation operations: %s\n", step.Description)
+	fmt.Fprintf(m.Out, "Finished operation: %s\n", step.Description)
 
 	for _, output := range step.Outputs {
 		//TODO populate the output

--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
+	"sort"
 	"testing"
 
 	"github.com/deislabs/porter/pkg/test"
@@ -11,38 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
 )
-
-func TestMixin_UnmarshalStep(t *testing.T) {
-	b, err := ioutil.ReadFile("testdata/step-input.yaml")
-	require.NoError(t, err)
-
-	var step Steps
-	err = yaml.Unmarshal(b, &step)
-	require.NoError(t, err)
-
-	assert.Equal(t, "Provision VM", step.Description)
-	assert.NotEmpty(t, step.Outputs)
-	assert.Equal(t, Output{"INSTANCE_ID", "$.Instances[0].InstanceId"}, step.Outputs[0])
-
-	assert.Equal(t, "ec2", step.Service)
-	assert.Equal(t, "run-instances", step.Operation)
-
-	assert.Equal(t, []string{"myinst"}, step.Arguments)
-	assert.Equal(t, Flags{
-		NewFlag("image-id", "ami-xxxxxxxx"),
-		NewFlag("instance-type", "t2.micro"),
-		NewFlag("env", "FOO=BAR", "STUFF=THINGS")}, step.Flags)
-}
-
-func TestMixin_UnmarshalInvalidStep(t *testing.T) {
-	b, err := ioutil.ReadFile("testdata/step-input-invalid.yaml")
-	require.NoError(t, err)
-
-	var step Steps
-	err = yaml.Unmarshal(b, &step)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid yaml type for flag env")
-}
 
 func TestMixin_UnmarshalInstallAction(t *testing.T) {
 	b, err := ioutil.ReadFile("testdata/install-input.yaml")
@@ -63,9 +32,11 @@ func TestMixin_UnmarshalInstallAction(t *testing.T) {
 	assert.Equal(t, "run-instances", step.Operation)
 
 	assert.Equal(t, []string{"myinst"}, step.Arguments)
-	assert.Equal(t, map[string]string{
-		"image-id":      "ami-xxxxxxxx",
-		"instance-type": "t2.micro"}, step.Flags)
+
+	sort.Sort(step.Flags)
+	assert.Equal(t, Flags{
+		NewFlag("image-id", "ami-xxxxxxxx"),
+		NewFlag("instance-type", "t2.micro")}, step.Flags)
 }
 
 func TestMixin_UnmarshalUpgradelAction(t *testing.T) {
@@ -86,9 +57,11 @@ func TestMixin_UnmarshalUpgradelAction(t *testing.T) {
 	assert.Equal(t, "create-tags", step.Operation)
 
 	assert.Empty(t, step.Arguments)
-	assert.Equal(t, map[string]string{
-		"resources": "i-5203422c",
-		"tags":      "Key=canary,Value=true"}, step.Flags)
+
+	sort.Sort(step.Flags)
+	assert.Equal(t, Flags{
+		NewFlag("resources", "i-5203422c"),
+		NewFlag("tags", "Key=canary,Value=true")}, step.Flags)
 }
 
 func TestMixin_UnmarshalUninstallAction(t *testing.T) {
@@ -109,8 +82,10 @@ func TestMixin_UnmarshalUninstallAction(t *testing.T) {
 	assert.Equal(t, "terminate-instances", step.Operation)
 
 	assert.Empty(t, step.Arguments)
-	assert.Equal(t, map[string]string{
-		"instance-ids": "i-5203422c i-5203422d"}, step.Flags)
+
+	sort.Sort(step.Flags)
+	assert.Equal(t, Flags{
+		NewFlag("instance-ids", "i-5203422c i-5203422d")}, step.Flags)
 }
 
 func TestMain(m *testing.M) {
@@ -123,17 +98,17 @@ func TestMixin_Execute(t *testing.T) {
 		wantCmd string
 		step    Step
 	}{
-		{"args, no flags", "aws s3 mb s3://mybucket",
+		{"args, no flags", "aws s3 mb s3://mybucket --output json",
 			Step{Service: "s3", Operation: "mb", Arguments: []string{"s3://mybucket"}},
 		},
-		{"no args, with flags", "aws ec2 run-instances --image-id ami-xxxxxxxx --instance-type t2.micro",
-			Step{Service: "ec2", Operation: "run-instances", Flags: []Flag{NewFlag("image-id", "ami-xxxxxxxx"), NewFlag("instance-type", "t2.micro")}},
+		{"no args, with flags", "aws ec2 run-instances --image-id ami-xxxxxxxx --instance-type t2.micro --output json",
+			Step{Service: "ec2", Operation: "run-instances", Flags: Flags{NewFlag("instance-type", "t2.micro"), NewFlag("image-id", "ami-xxxxxxxx")}},
 		},
-		{"args and flag", "aws ec2 run-instances myinst --image-id ami-xxxxxxxx --instance-type t2.micro",
+		{"args and flag", "aws ec2 run-instances myinst --image-id ami-xxxxxxxx --instance-type t2.micro --output json",
 			Step{Service: "ec2", Operation: "run-instances", Arguments: []string{"myinst"}, Flags: []Flag{NewFlag("image-id", "ami-xxxxxxxx"), NewFlag("instance-type", "t2.micro")}},
 		},
-		{"repeated flag", "aws ec2 run-instances --env FOO=BAR --env STUFF=THINGS",
-			Step{Service: "ec2", Operation: "run-instances", Flags: []Flag{NewFlag("env", "FOO=BAR", "STUFF=THINGS")}},
+		{"repeated flag", "aws ec2 run-instances --env FOO=BAR --env STUFF=THINGS --output json",
+			Step{Service: "ec2", Operation: "run-instances", Flags: Flags{NewFlag("env", "FOO=BAR", "STUFF=THINGS")}},
 		},
 	}
 
@@ -143,12 +118,16 @@ func TestMixin_Execute(t *testing.T) {
 			os.Setenv(test.ExpectedCommandEnv, tc.wantCmd)
 
 			action := Action{Steps: []Steps{{tc.step}}}
-			b, _ := yaml.Marshal(action)
+			b, err := yaml.Marshal(action)
+			require.NoError(t, err)
+
+			y := string(b)
+			t.Log(y)
 
 			h := NewTestMixin(t)
 			h.In = bytes.NewReader(b)
 
-			err := h.Execute()
+			err = h.Execute()
 
 			require.NoError(t, err)
 		})

--- a/pkg/aws/step.go
+++ b/pkg/aws/step.go
@@ -1,12 +1,64 @@
 package aws
 
+import "github.com/pkg/errors"
+
 type Step struct {
-	Description string            `yaml:"description"`
-	Service     string            `yaml:"service"`
-	Operation   string            `yaml:"operation"`
-	Arguments   []string          `yaml:"arguments"`
-	Flags       map[string]string `yaml:"flags"`
-	Outputs     []Output          `yaml:"outputs"`
+	Description string   `yaml:"description"`
+	Service     string   `yaml:"service"`
+	Operation   string   `yaml:"operation"`
+	Arguments   []string `yaml:"arguments"`
+	Flags       Flags    `yaml:"flags"`
+	Outputs     []Output `yaml:"outputs"`
+}
+
+type Flags []Flag
+type Flag struct {
+	Name   string
+	Values []string
+}
+
+func NewFlag(name string, values ...string) Flag {
+	f := Flag{
+		Name:   name,
+		Values: make([]string, len(values)),
+	}
+	copy(f.Values, values)
+	return f
+}
+
+// UnmarshalYAML takes any yaml in this form
+func (flags *Flags) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	flagMap := map[interface{}]interface{}{}
+	err := unmarshal(&flagMap)
+	if err != nil {
+		return errors.Wrap(err, "could not unmarshal yaml into Step.Flags")
+	}
+
+	*flags = make(Flags, 0, len(flagMap))
+	for k, v := range flagMap {
+		f := Flag{}
+		f.Name = k.(string)
+
+		switch t := v.(type) {
+		case string:
+			f.Values = make([]string, 1)
+			f.Values[0] = v.(string)
+		case []interface{}:
+			f.Values = make([]string, len(t))
+			for i := range t {
+				iv, ok := t[i].(string)
+				if !ok {
+					return errors.Errorf("invalid yaml type for flag %s: %T", f.Name, t[i])
+				}
+				f.Values[i] = iv
+			}
+		default:
+			return errors.Errorf("invalid yaml type for flag %s: %T", f.Name, t)
+		}
+
+		*flags = append(*flags, f)
+	}
+	return nil
 }
 
 type Output struct {

--- a/pkg/aws/step_test.go
+++ b/pkg/aws/step_test.go
@@ -1,0 +1,60 @@
+package aws
+
+import (
+	"io/ioutil"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlags_Sort(t *testing.T) {
+	flags := Flags{
+		NewFlag("b", "1"),
+		NewFlag("a", "2"),
+		NewFlag("c", "3"),
+	}
+
+	sort.Sort(flags)
+
+	assert.Equal(t, "a", flags[0].Name)
+	assert.Equal(t, "b", flags[1].Name)
+	assert.Equal(t, "c", flags[2].Name)
+}
+
+func TestMixin_UnmarshalStep(t *testing.T) {
+	b, err := ioutil.ReadFile("testdata/step-input.yaml")
+	require.NoError(t, err)
+
+	var step Steps
+	err = yaml.Unmarshal(b, &step)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Provision VM", step.Description)
+	assert.NotEmpty(t, step.Outputs)
+	assert.Equal(t, Output{"INSTANCE_ID", "$.Instances[0].InstanceId"}, step.Outputs[0])
+
+	assert.Equal(t, "ec2", step.Service)
+	assert.Equal(t, "run-instances", step.Operation)
+
+	assert.Equal(t, []string{"myinst"}, step.Arguments)
+
+	sort.Sort(step.Flags)
+	assert.Equal(t, Flags{
+		NewFlag("env", "FOO=BAR", "STUFF=THINGS"),
+		NewFlag("image-id", "ami-xxxxxxxx"),
+		NewFlag("instance-type", "t2.micro")}, step.Flags)
+}
+
+func TestMixin_UnmarshalInvalidStep(t *testing.T) {
+	b, err := ioutil.ReadFile("testdata/step-input-invalid.yaml")
+	require.NoError(t, err)
+
+	var step Steps
+	err = yaml.Unmarshal(b, &step)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid yaml type for flag env")
+}

--- a/pkg/aws/testdata/step-input-invalid.yaml
+++ b/pkg/aws/testdata/step-input-invalid.yaml
@@ -8,8 +8,4 @@ aws:
     image-id: ami-xxxxxxxx
     instance-type: t2.micro
     env:
-    - FOO=BAR
-    - STUFF=THINGS
-  outputs:
-    - name: "INSTANCE_ID"
-      jsonPath: "$.Instances[0].InstanceId"
+    - foo: [ "stuff", "things"]

--- a/vendor/github.com/gobuffalo/envy/.env
+++ b/vendor/github.com/gobuffalo/envy/.env
@@ -1,0 +1,5 @@
+# This is a comment
+# We can use equal or colon notation
+DIR: root
+FLAVOUR: none
+INSIDE_FOLDER=false


### PR DESCRIPTION
A flag can be repeated by making its values an array instead of a single
value.

```yaml
flags:
  env:
    - FOO=BAR
    - STUFF=THINGS
```

is turned into

`--env FOO=BAR --env STUFF=THINGS`